### PR TITLE
Update abinit_config.ac9

### DIFF
--- a/configs/abinit/abinit_config.ac9
+++ b/configs/abinit/abinit_config.ac9
@@ -7,10 +7,10 @@ with_linalg_flavor="netlib"
 LINALG_LIBS="-L/usr/lib/x86_64-linux-gnu -llapack -lblas"
 
 # mandatory libraries
-with_libxc="yes"
-with_hdf5="yes"
-with_netcdf="yes"
-with_netcdf_fortran="yes"
+#with_libxc="yes"
+#with_hdf5="yes"
+#with_netcdf="yes"
+#with_netcdf_fortran="yes"
 
 # fast fourier settings
 with_fft_flavor="fftw3"


### PR DESCRIPTION
In Abinit9, libxc, hdf5, and netcdf are considered hard-deps so setting :

```
with_libxc="yes"
with_hdf5="yes"
with_netcdf="yes"
with_netcdf_fortran="yes"
```

is, strictly speaking,  superfluous.
.
In principle, the build system should be able to find these libraries provided they are installed in standard locations.

To help the build sys find them when I load modules in HPC centers, I usually use:

```
with_netcdf=`nc-config --prefix`
with_hdf5=`nc-config --prefix`
with_fortran_netcdf=`nf-config --prefix`
```

but in your case everything is supposed to work out of the box without having to specify the locations of the libs.

If it doesn't, I would say it's a bug in the buildsys that should be addressed upstream.